### PR TITLE
fixed output bug

### DIFF
--- a/code/lib/poet_run.py
+++ b/code/lib/poet_run.py
@@ -259,7 +259,7 @@ def p6model(event=None, newdir=True, filedir='..', topdir=None, clip=None, idl=F
                 else:
                     wavelet = 'None'
                     
-                snrkeys = 'depth', 'depth2', 'depth3', 'trrprs', 'trrprs2', 'trqrprs', 'trq2rprs', 'rprs', 'rprs2', 'fpfs'
+                snrkeys = 'depth', 'depth2', 'depth3', 'trrprs', 'trrprs2', 'trqrprs', 'trq2rprs', 'rprs', 'rprs2', 'fpfs', 'btrprs', 'berprs'
                 for snrkey in snrkeys:
                     if hasattr(event[j].fit[i].i, snrkey):
                         snr   = event[j].fit[i].bestp  [getattr(event[j].fit[i].i, snrkey)] / \


### PR DESCRIPTION
Hi Kevin,
I am a student working with Laura Kreidberg and we noticed that the snrkeys ('btrprs', 'berprs') for the BATMAN models were missing. I added them in order to get a SDNR output in the results.txt file. 
